### PR TITLE
chore(*): remove information about the vanilla-like packet order in the readme goal list

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A high performance, multithreaded Minecraft server software which aims on high c
 ## Goals
 Jet, unlike many already existing options:
 - Has a goal to provide high customizability and control via API without need to use packets
-- Produces similar packet results to vanilla in pre-play protocol states and is at least as lenient as vanilla to be compatible with most of the already existing plugins, libraries, and clients
+- Is made to be compatible with most of the already existing plugins, libraries, and clients
 - Cares about code simplicity, readability and consistency, without compromising on the performance
 - Is designed to be friendly to developers, as well as normal users, thanks to the plugin system
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A high performance, multithreaded Minecraft server software which aims on high c
 ## Goals
 Jet, unlike many already existing options:
 - Has a goal to provide high customizability and control via API without need to use packets
-- Produces similar packet results to vanilla to be compatible with most of already existing plugins, libraries and clients
+- Produces similar packet results to vanilla in pre-play protocol states and is at least as lenient as vanilla to be compatible with most of the already existing plugins, libraries, and clients
 - Cares about code simplicity, readability and consistency, without compromising on the performance
 - Is designed to be friendly to developers, as well as normal users, thanks to the plugin system
 


### PR DESCRIPTION
**Description:**
It was decided to remove information about vanilla-like packet order in the readme goal list as the way of achieving compatibility with most of the already existing clients, libraries and plugins has changed. However, all protocol sessions are still going to be as lenient as in vanilla.